### PR TITLE
fix(bug): worker can have missing input parameter without throwing an exception

### DIFF
--- a/connect/connect-c8/worker-adapter-c8/src/main/java/io/miragon/miranum/connect/adapter/in/c8/worker/Camunda8WorkerAdapter.java
+++ b/connect/connect-c8/worker-adapter-c8/src/main/java/io/miragon/miranum/connect/adapter/in/c8/worker/Camunda8WorkerAdapter.java
@@ -34,9 +34,8 @@ public class Camunda8WorkerAdapter implements WorkerSubscription {
 
     public void execute(final JobClient client, final ActivatedJob job, final WorkerExecutor workerExecutor) {
         try {
-            final Map<String, Object> result = this.workerExecuteApi.execute(
-                    workerExecutor, job.getVariablesAsType(workerExecutor.getInputType())
-            );
+            var input = workerExecutor.hasInputType() ? job.getVariablesAsType(workerExecutor.getInputType()) : null;
+            final Map<String, Object> result = this.workerExecuteApi.execute(workerExecutor, input);
             final CompleteJobCommandStep1 cmd = client.newCompleteCommand(job.getKey());
             cmd.variables(result);
             cmd.send().join();

--- a/connect/connect-c8/worker-adapter-c8/src/test/java/io/miragon/miranum/connect/adapter/in/c8/worker/adapter/Camunda8AdapterTest.java
+++ b/connect/connect-c8/worker-adapter-c8/src/test/java/io/miragon/miranum/connect/adapter/in/c8/worker/adapter/Camunda8AdapterTest.java
@@ -42,6 +42,21 @@ public class Camunda8AdapterTest {
         then(client).should().newCompleteCommand(1L);
     }
 
+    @Test
+    void givenDefaultUseCaseWithNullInputType_thenShouldNotThrowAnyException() {
+        final ActivatedJob job = this.givenDefaultJob(1L);
+        final WorkerExecutor executor = this.givenDefaultExecutor("defaultUseCase", 100L);
+        given(executor.getInputType()).willReturn(null);
+        final Map<String, Object> result = Map.of("value", "test");
+        final JobClient client = this.givenDefaultClient(result);
+
+        given(this.workerExecuteApi.execute(any(), any())).willReturn(result);
+
+        this.adapter.execute(client, job, executor);
+
+        then(client).should().newCompleteCommand(1L);
+    }
+
     private ActivatedJob givenDefaultJob(final Long jobKey) {
         final ActivatedJob job = Mockito.mock(ActivatedJob.class);
         given(job.getKey()).willReturn(jobKey);

--- a/connect/connect-core/connect-worker/worker-api/src/main/java/io/miragon/miranum/connect/worker/impl/WorkerExecuteApiImpl.java
+++ b/connect/connect-core/connect-worker/worker-api/src/main/java/io/miragon/miranum/connect/worker/impl/WorkerExecuteApiImpl.java
@@ -39,7 +39,7 @@ public class WorkerExecuteApiImpl implements WorkerExecuteApi {
     private Object mapInput(final Class<?> inputType, final Object object) {
         final ObjectMapper mapper = new ObjectMapper();
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        return mapper.convertValue(object, inputType);
+        return Objects.nonNull(inputType) ? mapper.convertValue(object, inputType) : null;
     }
 
     private Map<String, Object> mapOutput(final Object output) {

--- a/connect/connect-core/connect-worker/worker-api/src/main/java/io/miragon/miranum/connect/worker/impl/WorkerExecutor.java
+++ b/connect/connect-core/connect-worker/worker-api/src/main/java/io/miragon/miranum/connect/worker/impl/WorkerExecutor.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Objects;
 
 @Getter
 @AllArgsConstructor
@@ -22,6 +23,10 @@ public class WorkerExecutor {
 
     private Class<?> outputType;
 
+    public boolean hasInputType() {
+        return Objects.nonNull(this.inputType);
+    }
+
     /**
      * Executes the worker.
      *
@@ -31,6 +36,8 @@ public class WorkerExecutor {
      * @throws IllegalAccessException    if this method object is enforcing Java language access control and the underlying method is inaccessible.
      */
     public Object execute(final Object data) throws InvocationTargetException, IllegalAccessException {
-        return this.getMethod().invoke(this.instance, data);
+        return hasInputType() ?
+                this.getMethod().invoke(this.instance, data) :
+                this.getMethod().invoke(this.instance);
     }
 }

--- a/connect/connect-core/connect-worker/worker-api/src/test/java/io/miragon/miranum/connect/worker/impl/WorkerExecuteApiImplTest.java
+++ b/connect/connect-core/connect-worker/worker-api/src/test/java/io/miragon/miranum/connect/worker/impl/WorkerExecuteApiImplTest.java
@@ -89,4 +89,15 @@ public class WorkerExecuteApiImplTest {
         Assertions.assertThrows(BusinessException.class, () ->
                 this.workerExecuteApi.execute(this.workerExecutor, this.event));
     }
+
+    @Test
+    void testExecuteWorker_withNullInputType_shouldNotThrowException() throws InvocationTargetException, IllegalAccessException {
+        when(this.workerExecutor.getType()).thenReturn("exampleWorker");
+        doReturn(null).when(this.workerExecutor).getInputType();
+        doReturn(Map.class).when(this.workerExecutor).getOutputType();
+        when(this.workerExecutor.execute(null)).thenReturn(this.event);
+
+        final Object result = this.workerExecuteApi.execute(this.workerExecutor, null);
+        Assertions.assertEquals(this.event, result);
+    }
 }

--- a/examples/simple-example/simple-example-camunda-8/src/main/resources/bpmn/message-c8.bpmn
+++ b/examples/simple-example/simple-example-camunda-8/src/main/resources/bpmn/message-c8.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_15jn3mj" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_15jn3mj" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.8.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
   <bpmn:process id="Process_1d0om0m" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_0698bym</bpmn:outgoing>
@@ -9,7 +9,7 @@
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="sendMessage" />
         <zeebe:ioMapping>
-          <zeebe:input source="= &#34;myMessage&#34;" target="name" />
+          <zeebe:input source="= &#34;myMessage&#34;" target="content" />
           <zeebe:input source="= &#34;myKey&#34;" target="key" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
@@ -28,14 +28,9 @@
   </bpmn:message>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1d0om0m">
-      <bpmndi:BPMNEdge id="Flow_1w6vdyo_di" bpmnElement="Flow_1w6vdyo">
-        <di:waypoint x="380" y="117" />
-        <di:waypoint x="442" y="117" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0698bym_di" bpmnElement="Flow_0698bym">
-        <di:waypoint x="188" y="117" />
-        <di:waypoint x="280" y="117" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1juy9v5_di" bpmnElement="Activity_1vhp7dw">
         <dc:Bounds x="280" y="77" width="100" height="80" />
         <bpmndi:BPMNLabel />
@@ -43,9 +38,14 @@
       <bpmndi:BPMNShape id="Event_0h3ms8a_di" bpmnElement="Event_0h3ms8a">
         <dc:Bounds x="442" y="99" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="152" y="99" width="36" height="36" />
-      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0698bym_di" bpmnElement="Flow_0698bym">
+        <di:waypoint x="188" y="117" />
+        <di:waypoint x="280" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1w6vdyo_di" bpmnElement="Flow_1w6vdyo">
+        <di:waypoint x="380" y="117" />
+        <di:waypoint x="442" y="117" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>


### PR DESCRIPTION
**Issue**
When a miranum worker is defined without providing an input parameter, the `CamundaXWorkerAdapter` throws an exception. The issue occurs in both Camunda 7 and Camunda 8 environments.


**Description**
This PR fixes #190.


**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
