### PR TITLE
fix(worker): exception message in process

### DIFF
--- a/connect/connect-c7/worker-adapter-c7/src/main/java/io/miragon/miranum/connect/adapter/in/c7/worker/Camunda7WorkerAdapter.java
+++ b/connect/connect-c7/worker-adapter-c7/src/main/java/io/miragon/miranum/connect/adapter/in/c7/worker/Camunda7WorkerAdapter.java
@@ -42,7 +42,7 @@ public class Camunda7WorkerAdapter implements WorkerSubscription {
             service.complete(externalTask, null, camunda7PojoMapper.mapToEngineData(result));
         } catch (final BusinessException exception) {
             log.severe("use case could not be executed " + exception.getMessage());
-            service.handleBpmnError(externalTask, exception.getCode());
+            service.handleBpmnError(externalTask, exception.getCode(), exception.getMessage());
         } catch (final TechnicalException error) {
             log.severe("Technical error while executing task " + error.getMessage());
             service.handleFailure(externalTask, error.getMessage(), Arrays.toString(error.getStackTrace()), 0, 0L);
@@ -62,7 +62,7 @@ public class Camunda7WorkerAdapter implements WorkerSubscription {
      * For subsequent runs, where externalTaskRetries is not null, it is used.
      *
      * @param externalTaskRetries The number of retries specified for the external task.
-     * @param workerRetries The number of retries specified for the worker as an input in the bpmn.
+     * @param workerRetries       The number of retries specified for the worker as an input in the bpmn.
      * @return The remaining number of retries for the task.
      */
     private int getRemainingRetries(Integer externalTaskRetries, Integer workerRetries) {
@@ -71,7 +71,7 @@ public class Camunda7WorkerAdapter implements WorkerSubscription {
             retries = Objects.isNull(workerRetries) ?
                     camunda7WorkerProperties.getDefaultRetries() :
                     workerRetries;
-        }else {
+        } else {
             retries = externalTaskRetries;
         }
         retries -= 1;


### PR DESCRIPTION
**Issue**
When throwing a business exception, its message is not available in the process instance


**Description**
I fixed it by adding the message to the handleBpmnError() method


**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
